### PR TITLE
Update dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ trim.all = function (tokens) {
     var next = tokens[i + 1]
     var prev = tokens[i - 1]
 
-    if (next && next.type === 'preprocessor' || prev && prev.type === 'preprocessor') {
+    if ((next && next.type === 'preprocessor') || (prev && prev.type === 'preprocessor')) {
       token.data = token.data.replace(all, '\n')
     } else {
       token.data = token.data.replace(all, ' ')

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "gl": "^2.1.5",
+    "gl": "^4.2.2",
     "gl-shader": "^4.0.6",
     "glsl-token-string": "^1.0.1",
     "glsl-tokenizer": "^2.0.2",
-    "standard": "^5.4.1",
-    "tap-spec": "^4.1.1",
+    "standard": "^12.0.1",
+    "tap-spec": "^5.0.0",
     "tape": "^4.2.2"
   },
   "scripts": {


### PR DESCRIPTION
## Problem
`npm install` fails in `master` now.. 
This package depends on an obsolete version of `gl` and it throws an error on install.

<details>
<summary>The error message is as follows:</summary>

```
glsl-token-whitespace-trim git:master ✩  ❯ npm i
npm WARN deprecated standard-format@1.6.10: standard-format is deprecated in favor of a built-in autofixer in 'standard'. Usage: standard --fix
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue

> gl@2.1.5 install /Users/amagi/src/github.com/fand/glsl-token-whitespace-trim/node_modules/gl
> prebuild --download

prebuild info begin Prebuild version 2.9.2
prebuild info looking for local prebuild @ prebuilds/gl-v2.1.5-node-v67-darwin-x64.tar.gz
prebuild info looking for cached prebuild @ /Users/amagi/.npm/_prebuilds/https-github.com-stackgl-headless-gl-releases-download-v2.1.5-gl-v2.1.5-node-v67-darwin-x64.tar.gz
prebuild http request GET https://github.com/stackgl/headless-gl/releases/download/v2.1.5/gl-v2.1.5-node-v67-darwin-x64.tar.gz
prebuild http 404 https://github.com/stackgl/headless-gl/releases/download/v2.1.5/gl-v2.1.5-node-v67-darwin-x64.tar.gz
prebuild WARN install Prebuilt binaries for node version 0.10.40,0.12.7,1.0.4,1.8.4,2.4.0,3.3.1,4.1.1 are not available
prebuild info install We will now try to compile from source.
prebuild verb starting node-gyp process
prebuild verb execute node-gyp with `node index.js rebuild --target=0.10.40,0.12.7,1.0.4,1.8.4,2.4.0,3.3.1,4.1.1 --target_arch=x64`
prebuild verb ok
prebuild verb ok
prebuild ERR! configure error
prebuild ERR! stack Error: Invalid version number: 0.10.40,0.12.7,1.0.4,1.8.4,2.4.0,3.3.1,4.1.1
prebuild ERR! stack     at getNodeDir (/Users/amagi/src/github.com/fand/glsl-token-whitespace-trim/node_modules/node-gyp/lib/configure.js:72:25)
prebuild ERR! stack     at PythonFinder.callback (/Users/amagi/src/github.com/fand/glsl-token-whitespace-trim/node_modules/node-gyp/lib/configure.js:44:7)
prebuild ERR! stack     at PythonFinder.<anonymous> (/Users/amagi/src/github.com/fand/glsl-token-whitespace-trim/node_modules/node-gyp/lib/configure.js:471:14)
prebuild ERR! stack     at ChildProcess.exithandler (child_process.js:288:7)
prebuild ERR! stack     at ChildProcess.emit (events.js:197:13)
prebuild ERR! stack     at maybeClose (internal/child_process.js:988:16)
prebuild ERR! stack     at Socket.stream.socket.on (internal/child_process.js:404:11)
prebuild ERR! stack     at Socket.emit (events.js:197:13)
prebuild ERR! stack     at Pipe._handle.close (net.js:611:12)
prebuild ERR! not ok
prebuild ERR! build Error: Invalid version number: 0.10.40,0.12.7,1.0.4,1.8.4,2.4.0,3.3.1,4.1.1
prebuild ERR! build     at getNodeDir (/Users/amagi/src/github.com/fand/glsl-token-whitespace-trim/node_modules/node-gyp/lib/configure.js:72:25)
prebuild ERR! build     at PythonFinder.callback (/Users/amagi/src/github.com/fand/glsl-token-whitespace-trim/node_modules/node-gyp/lib/configure.js:44:7)
prebuild ERR! build     at PythonFinder.<anonymous> (/Users/amagi/src/github.com/fand/glsl-token-whitespace-trim/node_modules/node-gyp/lib/configure.js:471:14)
prebuild ERR! build     at ChildProcess.exithandler (child_process.js:288:7)
prebuild ERR! build     at ChildProcess.emit (events.js:197:13)
prebuild ERR! build     at maybeClose (internal/child_process.js:988:16)
prebuild ERR! build     at Socket.stream.socket.on (internal/child_process.js:404:11)
prebuild ERR! build     at Socket.emit (events.js:197:13)
prebuild ERR! build     at Pipe._handle.close (net.js:611:12)
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! gl@2.1.5 install: `prebuild --download`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the gl@2.1.5 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/amagi/.npm/_logs/2019-03-29T15_07_02_498Z-debug.log
 ⌚︎ 16s
```
</details>

## Changes
- Updated `gl` to the latest one
- Updated other libraries (`standard` and `tap-spec`)
- Fixed warnings by `standard`